### PR TITLE
Allow passing through additional arguments to `nix build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+# Unreleased
+
+- Pass the rest of CLI arguments after `--` as-is to `nix build`
+    - Consequently, remove `--rebuild`, `--no-refresh` and `--system` options, because these can be specified using the new CLI spec.
+
+
 # 0.1.3
 
 - Pass `-j auto` to nix builds.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,23 +52,15 @@ pub struct CliArgs {
     #[arg(short = 'v')]
     pub verbose: bool,
 
-    /// Whether to pass --rebuild to nix
-    #[arg(long)]
-    pub rebuild: bool,
-
-    /// Whether to avoid passing --refresh to nix
-    #[arg(long)]
-    pub no_refresh: bool,
-
-    /// What system to build the Nix expressions for
-    #[arg(long, short)]
-    pub system: Option<String>,
-
     /// Flake URL or github URL
     #[arg(default_value = ".")]
     pub flake_ref: FlakeRef,
 
     /// Additional arguments to pass through to `nix build`
-    #[arg(last = true)]
+    #[arg(last = true, default_values_t = vec![
+        "--refresh".to_string(),
+        "-j".to_string(),
+        "auto".to_string(),
+    ])]
     pub extra_nix_build_args: Vec<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,4 +67,8 @@ pub struct CliArgs {
     /// Flake URL or github URL
     #[arg(default_value = ".")]
     pub flake_ref: FlakeRef,
+
+    /// Additional arguments to pass through to `nix build`
+    #[arg(last = true)]
+    pub extra_nix_build_args: Vec<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,7 @@ impl SubFlakish {
         extra_args.push("auto".to_string());
 
         extra_args.insert(0, self.sub_flake_url(flake_url));
+        extra_args.extend(cli_args.extra_nix_build_args.iter().cloned());
         extra_args
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,26 +84,6 @@ impl SubFlakish {
                 ]
             })
             .collect::<Vec<String>>();
-        if cli_args.rebuild {
-            extra_args.push("--rebuild".to_string());
-        }
-        if !cli_args.no_refresh {
-            extra_args.push("--refresh".to_string());
-        }
-        match &cli_args.system {
-            Some(system) => {
-                extra_args.append(&mut vec![
-                    "--option".to_string(),
-                    "system".to_string(),
-                    system.clone(),
-                ]);
-            }
-            None => (),
-        }
-
-        // Parallel downloads and builds
-        extra_args.push("-j".to_string());
-        extra_args.push("auto".to_string());
 
         extra_args.insert(0, self.sub_flake_url(flake_url));
         extra_args.extend(cli_args.extra_nix_build_args.iter().cloned());


### PR DESCRIPTION
Allow easily passing additional arguments to `nix build` by passing them after `--`

For example: `nixci . -- --print-build-logs --keep-going`

Resolves #8 