### PR TITLE
Allow overriding the nixci config attribute to evaluate

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,37 +7,44 @@ use crate::github::{self, PullRequest, PullRequestRef};
 
 /// A reference to some flake living somewhere
 #[derive(Debug, Clone)]
-pub enum FlakeRef {
+pub struct FlakeRef {
+    /// Which flake attribute to evaluate for the configuration
+    pub config_attr: String,
+    /// What kind of flake ref we're dealing with
+    kind: FlakeKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum FlakeKind {
     /// A github PR
     GithubPR(PullRequestRef),
     /// A flake URL supported by Nix commands
     Flake(String),
 }
 
-impl Default for FlakeRef {
-    fn default() -> Self {
-        let root_flake = FlakeRef::Flake(".".to_string());
-        root_flake
-    }
-}
-
 impl FromStr for FlakeRef {
     type Err = String;
-    fn from_str(s: &str) -> std::result::Result<FlakeRef, String> {
-        let flake_ref = match github::PullRequestRef::from_web_url(&s.to_string()) {
-            Some(pr) => FlakeRef::GithubPR(pr),
-            None => FlakeRef::Flake(s.to_string()),
-        };
-        Ok(flake_ref)
+    fn from_str(input: &str) -> std::result::Result<FlakeRef, String> {
+        let mut split = input.split('#');
+        let s = split.next().unwrap_or(input);
+        let config_attr = split.next().unwrap_or("nixci").to_owned();
+
+        Ok(Self {
+            config_attr,
+            kind: match github::PullRequestRef::from_web_url(s) {
+                Some(pr) => FlakeKind::GithubPR(pr),
+                None => FlakeKind::Flake(s.to_string()),
+            },
+        })
     }
 }
 
 impl FlakeRef {
     /// Convert the value to a flake URL that Nix command will recognize.
     pub fn to_flake_url(&self) -> Result<String> {
-        match self {
-            FlakeRef::GithubPR(pr) => Ok(PullRequest::get(&pr)?.flake_url()),
-            FlakeRef::Flake(url) => Ok(url.clone()),
+        match &self.kind {
+            FlakeKind::GithubPR(pr) => Ok(PullRequest::get(&pr)?.flake_url()),
+            FlakeKind::Flake(url) => Ok(url.clone()),
         }
     }
 }
@@ -52,8 +59,9 @@ pub struct CliArgs {
     #[arg(short = 'v')]
     pub verbose: bool,
 
-    /// Flake URL or github URL
-    #[arg(default_value = ".")]
+    /// Flake URL or github URL. If no configuration attribute is specified, `nixci` will be used
+    /// by default.
+    #[arg(default_value = ".#nixci")]
     pub flake_ref: FlakeRef,
 
     /// Additional arguments to pass through to `nix build`

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,10 @@ use std::collections::{BTreeMap, HashMap};
 use anyhow::Result;
 use serde::Deserialize;
 
-use crate::{cli::CliArgs, nix};
+use crate::{
+    cli::{CliArgs, FlakeRef},
+    nix,
+};
 
 /// Rust type for the `nixci` flake output
 ///
@@ -30,8 +33,8 @@ impl Default for Config {
 }
 
 impl Config {
-    pub fn from_flake_url(url: String) -> Result<Self> {
-        nix::eval::nix_eval_attr_json::<Config>("nixci", url)
+    pub fn from_flake_url(flake_ref: &FlakeRef, url: String) -> Result<Self> {
+        nix::eval::nix_eval_attr_json::<Config>(&*flake_ref.config_attr, url)
     }
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -21,7 +21,7 @@ impl PullRequestRef {
         )
     }
     /// Parse a Github PR URL into its owner, repo, and PR number
-    pub fn from_web_url(url: &String) -> Option<Self> {
+    pub fn from_web_url(url: &str) -> Option<Self> {
         let url = Url::parse(url).ok()?;
         guard!(url.scheme() == "https" && url.host() == Some(Host::Domain("github.com")));
         let paths = url.path_segments().map(|c| c.collect::<Vec<_>>())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
     let url = args.flake_ref.to_flake_url()?;
     eprintln!("{}", format!("🍏 {}", url).bold());
 
-    let cfgs = config::Config::from_flake_url(url.clone())?;
+    let cfgs = config::Config::from_flake_url(&args.flake_ref, url.clone())?;
     if args.verbose {
         eprintln!("DEBUG {cfgs:?}");
     }


### PR DESCRIPTION
This allows invoking `nixci .#alt-config` which will evalute the `alt-config` attribute in the current flake. If not specified, it will fallback to using `nixci` as a default for backwards compatible behavior.

This is useful for situations where one might want to split up their `nixci` configs. For example, I have a project with a very large test suite (tests on both nixpkgs-unstable, as well as the latest release) and building all subflakes in one go makes the Github Action runners run out of disk space. But with this feature I can split up my configs in to separate "runs"