### PR TITLE
Add `--uncached` flag for only building uncached derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693774442,
-        "narHash": "sha256-LAaAybUeYNg3Uk0DrNIwXp4Vyrf32P4VHphYfM6i/IA=",
+        "lastModified": 1693779869,
+        "narHash": "sha256-kH7FB9EdxQhpwP9AsP9mCA6YcfE4xcKfKAR1Lvu76Ho=",
         "owner": "ipetkov",
         "repo": "devour-flake",
-        "rev": "d3968c27df1afa35a2e7437960a3662a9877399b",
+        "rev": "8df0c8a52536d281583e59fb673b06a593ee8522",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,18 +35,28 @@
       }
     },
     "devour-flake": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": [
+          "systems"
+        ]
+      },
       "locked": {
-        "lastModified": 1689267783,
-        "narHash": "sha256-CZedJtbZlWAbv/b/aYgOEFd9vcTBn/oJNI3p29UitLk=",
-        "owner": "srid",
+        "lastModified": 1693774442,
+        "narHash": "sha256-LAaAybUeYNg3Uk0DrNIwXp4Vyrf32P4VHphYfM6i/IA=",
+        "owner": "ipetkov",
         "repo": "devour-flake",
-        "rev": "f4d8c8eaade5fefe0d466c4bb90215d387eadc23",
+        "rev": "d3968c27df1afa35a2e7437960a3662a9877399b",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
-        "ref": "v2",
+        "owner": "ipetkov",
+        "ref": "uncached",
         "repo": "devour-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -35,105 +35,105 @@
       ];
 
       perSystem = { config, self', pkgs, lib, system, ... }:
-      let
-        devour-flake = inputs.devour-flake.packages.${system}.default;
-      in
-      {
-        # Rust project definition
-        # cf. https://github.com/nix-community/dream2nix
-        dream2nix.inputs."nixci" = {
-          source = lib.sourceFilesBySuffices ./. [
-            ".rs"
-            "Cargo.toml"
-            "Cargo.lock"
-          ];
-          projects."nixci" = { name, ... }: {
-            inherit name;
-            subsystem = "rust";
-            translator = "cargo-lock";
-          };
-          packageOverrides =
-            let
-              common = {
-                add-deps = with pkgs; with pkgs.darwin.apple_sdk.frameworks; {
-                  nativeBuildInputs = old: old ++ lib.optionals stdenv.isDarwin [
-                    Security
-                  ] ++ [
-                    libiconv
-                    openssl
-                    pkgconfig
-                  ];
-                };
-              };
-            in
-            {
-              # Project and dependency overrides:
-              nixci = common // { };
-              nixci-deps = common;
+        let
+          devour-flake = inputs.devour-flake.packages.${system}.default;
+        in
+        {
+          # Rust project definition
+          # cf. https://github.com/nix-community/dream2nix
+          dream2nix.inputs."nixci" = {
+            source = lib.sourceFilesBySuffices ./. [
+              ".rs"
+              "Cargo.toml"
+              "Cargo.lock"
+            ];
+            projects."nixci" = { name, ... }: {
+              inherit name;
+              subsystem = "rust";
+              translator = "cargo-lock";
             };
-        };
-
-        # Flake outputs
-        packages.default =
-          let nixci = config.dream2nix.outputs.nixci.packages.nixci;
-          in nixci.overrideAttrs (old: {
-            DEVOUR_FLAKE = devour-flake;
-          });
-        overlayAttrs.nixci = self'.packages.default;
-
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [
-            config.dream2nix.outputs.nixci.devShells.default
-            config.treefmt.build.devShell
-            config.mission-control.devShell
-            config.flake-root.devShell
-          ];
-          shellHook = ''
-            # For rust-analyzer 'hover' tooltips to work.
-            export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc}
-            export DEVOUR_FLAKE=${devour-flake}
-          '';
-          nativeBuildInputs = [
-            pkgs.cargo-watch
-            pkgs.clippy
-            pkgs.rust-analyzer
-            devour-flake
-          ];
-        };
-
-        # Add your auto-formatters here.
-        # cf. https://numtide.github.io/treefmt/
-        treefmt.config = {
-          projectRootFile = "flake.nix";
-          programs = {
-            nixpkgs-fmt.enable = true;
-            rustfmt.enable = true;
-          };
-        };
-
-        # Makefile'esque but in Nix. Add your dev scripts here.
-        # cf. https://github.com/Platonic-Systems/mission-control
-        mission-control.scripts = {
-          fmt = {
-            exec = config.treefmt.build.wrapper;
-            description = "Auto-format project tree";
+            packageOverrides =
+              let
+                common = {
+                  add-deps = with pkgs; with pkgs.darwin.apple_sdk.frameworks; {
+                    nativeBuildInputs = old: old ++ lib.optionals stdenv.isDarwin [
+                      Security
+                    ] ++ [
+                      libiconv
+                      openssl
+                      pkgconfig
+                    ];
+                  };
+                };
+              in
+              {
+                # Project and dependency overrides:
+                nixci = common // { };
+                nixci-deps = common;
+              };
           };
 
-          run = {
-            exec = ''
-              cargo run "$@"
+          # Flake outputs
+          packages.default =
+            let nixci = config.dream2nix.outputs.nixci.packages.nixci;
+            in nixci.overrideAttrs (old: {
+              DEVOUR_FLAKE = devour-flake;
+            });
+          overlayAttrs.nixci = self'.packages.default;
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [
+              config.dream2nix.outputs.nixci.devShells.default
+              config.treefmt.build.devShell
+              config.mission-control.devShell
+              config.flake-root.devShell
+            ];
+            shellHook = ''
+              # For rust-analyzer 'hover' tooltips to work.
+              export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc}
+              export DEVOUR_FLAKE=${devour-flake}
             '';
-            description = "Run the project executable";
+            nativeBuildInputs = [
+              pkgs.cargo-watch
+              pkgs.clippy
+              pkgs.rust-analyzer
+              devour-flake
+            ];
           };
 
-          watch = {
-            exec = ''
-              set -x
-              cargo watch -x "run -- $*"
-            '';
-            description = "Watch for changes and run the project executable";
+          # Add your auto-formatters here.
+          # cf. https://numtide.github.io/treefmt/
+          treefmt.config = {
+            projectRootFile = "flake.nix";
+            programs = {
+              nixpkgs-fmt.enable = true;
+              rustfmt.enable = true;
+            };
+          };
+
+          # Makefile'esque but in Nix. Add your dev scripts here.
+          # cf. https://github.com/Platonic-Systems/mission-control
+          mission-control.scripts = {
+            fmt = {
+              exec = config.treefmt.build.wrapper;
+              description = "Auto-format project tree";
+            };
+
+            run = {
+              exec = ''
+                cargo run "$@"
+              '';
+              description = "Run the project executable";
+            };
+
+            watch = {
+              exec = ''
+                set -x
+                cargo watch -x "run -- $*"
+              '';
+              description = "Watch for changes and run the project executable";
+            };
           };
         };
-      };
     };
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,10 @@ pub struct CliArgs {
     #[arg(short = 'v')]
     pub verbose: bool,
 
+    /// Only build derivations for whom binary caches are not available
+    #[arg(long)]
+    pub uncached: bool,
+
     /// Flake URL or github URL
     #[arg(default_value = ".")]
     pub flake_ref: FlakeRef,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-mod cli;
+pub(crate) mod cli;
 mod config;
 mod github;
 mod nix;
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
             nix::lock::nix_flake_lock_check(&cfg.sub_flake_url(&url))?;
         }
 
-        let outs = nix::devour_flake::devour_flake(args.verbose, nix_args)?;
+        let outs = nix::devour_flake::devour_flake(&args, nix_args)?;
         if outs.is_empty() {
             eprintln!("Warn: devour-flake produced no outputs")
         } else {

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -7,8 +7,8 @@ use tokio::{
     process::Command,
 };
 
-use crate::cli::CliArgs;
 use super::util::print_shell_command;
+use crate::cli::CliArgs;
 
 /// Absolute path to the devour-flake executable
 ///

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -7,21 +7,30 @@ use tokio::{
     process::Command,
 };
 
+use crate::cli::CliArgs;
 use super::util::print_shell_command;
 
 /// Absolute path to the devour-flake executable
 ///
 /// We expect this environment to be set in Nix build and shell.
-pub const DEVOUR_FLAKE: &str = env!("DEVOUR_FLAKE");
+pub const DEVOUR_FLAKE: &str = concat!(env!("DEVOUR_FLAKE"), "/bin/devour-flake");
+pub const DEVOUR_FLAKE_UNCACHED: &str = concat!(env!("DEVOUR_FLAKE"), "/bin/devour-flake-uncached");
 
 /// Nix derivation output path
 pub struct DrvOut(pub String);
 
 #[tokio::main]
-pub async fn devour_flake(verbose: bool, args: Vec<String>) -> Result<Vec<DrvOut>> {
-    print_shell_command(DEVOUR_FLAKE, args.iter().map(|s| &**s));
-    let mut output_fut = Command::new(DEVOUR_FLAKE)
-        .args(args)
+pub async fn devour_flake(args: &CliArgs, nix_args: Vec<String>) -> Result<Vec<DrvOut>> {
+    let verbose = args.verbose;
+    let exe = if args.uncached {
+        DEVOUR_FLAKE_UNCACHED
+    } else {
+        DEVOUR_FLAKE
+    };
+
+    print_shell_command(exe, nix_args.iter().map(|s| &**s));
+    let mut output_fut = Command::new(exe)
+        .args(nix_args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;


### PR DESCRIPTION
Related to https://github.com/srid/devour-flake/pull/10, which allows for incrementally building only derivations not already present in the cache (which avoids the pitfall of wasting cycles and bandwidth from downloading artifacts already in the cache) 