### PR TITLE
ci: Add self-hosted runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: "CI"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  nix:
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        system: [aarch64-darwin, aarch64-linux]
+    steps:
+      - uses: actions/checkout@v4
+      - run: nixci --build-systems "github:nix-systems/${{ matrix.system }}"

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,4 +1,5 @@
+# Only building to provide package cache
 builds:
   include:
-    - "*.aarch64-darwin.*"
-    - "*.x86_64-linux.*"
+    - "packages.aarch64-darwin.default"
+    - "packages.x86_64-linux.default"


### PR DESCRIPTION
Use garnix only for master branch package cache