### PR TITLE
feat: Accept global options to pass to Nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,12 +791,13 @@ dependencies = [
 
 [[package]]
 name = "nix_rs"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaac3ae7302d82acade21e9ca26d7cb052fa9b713ec77985def9c6d19dbe63cc"
+checksum = "da25f502c0280182deca738d14d878c77e5886d5d9af60e8d51c150afbd9b7e5"
 dependencies = [
  "bytesize",
  "cfg-if",
+ "clap",
  "colored",
  "is_proc_translated",
  "os_info",
@@ -814,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "nixci"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Sridhar Ratnakumar <srid@srid.ca>"]
 edition = "2021"
 # If you change the name here, you must also do it in flake.nix (and run `cargo generate-lockfile` afterwards)
 name = "nixci"
-version = "0.4.0"
+version = "0.5.0"
 license = "AGPL-3.0-only"
 readme = "README.md"
 description = "Define and build CI for Nix projects anywhere"
@@ -27,8 +27,8 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 try-guard = "0.2.0"
 clap = { version = "4.4", features = ["derive"] }
 urlencoding = "2.1.3"
-nix_rs = { version = "0.3.3" }
-# nix_rs = { version = "0.3.2", path = "../nix-rs" }
+nix_rs = { version = "0.5.0", features = ["clap"] }
+# nix_rs = { version = "0.5.0", path = "../nix-rs", features = ["clap"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing = "0.1.37"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ pub struct CliArgs {
     /// Whether to be verbose
     ///
     /// If enabled, also the full nix command output is shown.
-    #[arg(short = 'v')]
+    #[arg(short = 'v', long)]
     pub verbose: bool,
 
     /// Nix command global options

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use nix_rs::{
-    command::NixCmdError,
+    command::{NixCmd, NixCmdError},
     config::NixConfig,
     flake::{system::System, url::FlakeUrl},
 };
@@ -57,6 +57,10 @@ pub struct CliArgs {
     /// If enabled, also the full nix command output is shown.
     #[arg(short = 'v')]
     pub verbose: bool,
+
+    /// Nix command global options
+    #[command(flatten)]
+    pub nixcmd: NixCmd,
 
     #[clap(subcommand)]
     pub command: Command,
@@ -144,7 +148,7 @@ impl BuildConfig {
 }
 
 async fn get_current_system() -> Result<System, NixCmdError> {
-    let cmd = crate::nixcmd().await;
+    let cmd = crate::NIXCMD.get().unwrap();
     let config = NixConfig::from_nix(cmd).await?;
     Ok(config.system.value)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ impl Config {
     /// ```
     /// along with the config.
     pub async fn from_flake_url(url: &FlakeUrl) -> Result<Config> {
-        let cmd = crate::nixcmd().await;
+        let cmd = crate::NIXCMD.get().unwrap();
         let (flake_url, attr) = url.split_attr();
         let nested_attr = attr.as_list();
         let (name, selected_subflake) = match nested_attr.as_slice() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
-use clap::Parser;
 use nixci::cli;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = cli::CliArgs::parse();
+    let args = cli::CliArgs::parse().await?;
     nixci::logging::setup_logging(args.verbose);
     nixci::nixci(args).await?;
     Ok(())

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -35,7 +35,7 @@ impl FromStr for DevourFlakeOutput {
 pub async fn devour_flake(verbose: bool, args: Vec<String>) -> Result<DevourFlakeOutput> {
     // TODO: Use nix_rs here as well
     // In the context of doing https://github.com/srid/nixci/issues/15
-    let nix = crate::nixcmd().await;
+    let nix = crate::NIXCMD.get().unwrap();
     let mut cmd = nix.command();
     let devour_flake_url = format!("{}#default", env!("DEVOUR_FLAKE"));
     cmd.args([

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -1,6 +1,7 @@
 //! Rust support for invoking <https://github.com/srid/devour-flake>
 
 use anyhow::{bail, Context, Result};
+use nix_rs::command::NixCmd;
 use std::{collections::HashSet, path::PathBuf, process::Stdio, str::FromStr};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -32,12 +33,15 @@ impl FromStr for DevourFlakeOutput {
     }
 }
 
-pub async fn devour_flake(verbose: bool, args: Vec<String>) -> Result<DevourFlakeOutput> {
+pub async fn devour_flake(
+    nixcmd: &NixCmd,
+    verbose: bool,
+    args: Vec<String>,
+) -> Result<DevourFlakeOutput> {
     // TODO: Use nix_rs here as well
     // In the context of doing https://github.com/srid/nixci/issues/15
-    let nix = crate::NIXCMD.get().unwrap();
-    let mut cmd = nix.command();
     let devour_flake_url = format!("{}#default", env!("DEVOUR_FLAKE"));
+    let mut cmd = nixcmd.command();
     cmd.args([
         "build",
         &devour_flake_url,

--- a/src/nix/lock.rs
+++ b/src/nix/lock.rs
@@ -5,7 +5,7 @@ use nix_rs::flake::url::FlakeUrl;
 
 /// Make sure that the `flake.lock` file is in sync.
 pub async fn nix_flake_lock_check(url: &FlakeUrl) -> Result<()> {
-    let nix = crate::nixcmd().await;
+    let nix = crate::NIXCMD.get().unwrap();
     let mut cmd = nix.command();
     cmd.args(["flake", "lock", "--no-update-lock-file", &url.0]);
     nix_rs::command::trace_cmd(&cmd);

--- a/src/nix/lock.rs
+++ b/src/nix/lock.rs
@@ -1,12 +1,11 @@
 use std::process::Stdio;
 
 use anyhow::{bail, Result};
-use nix_rs::flake::url::FlakeUrl;
+use nix_rs::{command::NixCmd, flake::url::FlakeUrl};
 
 /// Make sure that the `flake.lock` file is in sync.
-pub async fn nix_flake_lock_check(url: &FlakeUrl) -> Result<()> {
-    let nix = crate::NIXCMD.get().unwrap();
-    let mut cmd = nix.command();
+pub async fn nix_flake_lock_check(nixcmd: &NixCmd, url: &FlakeUrl) -> Result<()> {
+    let mut cmd = nixcmd.command();
     cmd.args(["flake", "lock", "--no-update-lock-file", &url.0]);
     nix_rs::command::trace_cmd(&cmd);
     let status = cmd.stdin(Stdio::null()).spawn()?.wait().await?;

--- a/src/nix/system_list.rs
+++ b/src/nix/system_list.rs
@@ -53,7 +53,7 @@ async fn nix_eval_impure_expr<T>(expr: String) -> Result<T, NixCmdError>
 where
     T: Default + serde::de::DeserializeOwned,
 {
-    let nix = crate::nixcmd().await;
+    let nix = crate::NIXCMD.get().unwrap();
     let v = nix
         .run_with_args_expecting_json::<T>(&["eval", "--impure", "--json", "--expr", &expr])
         .await?;
@@ -64,6 +64,13 @@ where
 #[cfg(feature = "integration_test")]
 mod tests {
     use super::*;
+
+    #[ctor::ctor]
+    fn init() {
+        crate::NIXCMD
+            .set(nix_rs::command::NixCmd::default())
+            .unwrap();
+    }
 
     #[tokio::test]
     async fn test_empty_systems_list() {


### PR DESCRIPTION
In particular, the following global Nix options can now be passed to nixci:

```
      --extra-experimental-features <EXTRA_EXPERIMENTAL_FEATURES>
          Append to the experimental-features setting of Nix

      --extra-access-tokens <EXTRA_ACCESS_TOKENS>
          Append to the access-tokens setting of Nix

      --refresh
          Consider all previously downloaded files out-of-date
```

This is made possible by the following two PRs to `nix-rs`:

- https://github.com/juspay/nix-rs/pull/10
- https://github.com/juspay/nix-rs/pull/11