### PR TITLE
fix: `--print-all-dependencies` should handle `unknown-deriver`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0"
+thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -1,3 +1,6 @@
+/// Run `nix-store` in Rust
+///
+/// TODO: Upstream this to nix-rs
 use std::{fmt, path::PathBuf};
 
 use anyhow::Result;
@@ -97,7 +100,7 @@ impl NixStoreCmd {
         if out.status.success() {
             let drv_path = String::from_utf8(out.stdout)?.trim().to_string();
             if drv_path == "unknown-deriver" {
-                return Err(NixStoreCmdError::UnknownDeriverError);
+                return Err(NixStoreCmdError::UnknownDeriver);
             }
             Ok(DrvOut(PathBuf::from(drv_path)))
         } else {
@@ -140,15 +143,14 @@ impl NixStoreCmd {
     }
 }
 
-/// Errors when running and interpreting the output of a nix command.
-/// Extended with NixCmdError from nix_rs
+/// `nix-store` command errors
 #[derive(Error, Debug)]
 pub enum NixStoreCmdError {
     #[error(transparent)]
     NixCmdError(#[from] NixCmdError),
 
     #[error("Unknown deriver")]
-    UnknownDeriverError,
+    UnknownDeriver,
 }
 
 impl From<std::io::Error> for NixStoreCmdError {

--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -92,6 +92,11 @@ impl NixStoreCmd {
         let out = cmd.output().await.map_err(CommandError::ChildProcessError)?;
         if out.status.success() {
             let drv_path = String::from_utf8(out.stdout)?.trim().to_string();
+            if drv_path.contains("unknown-deriver") {
+                let exit_code = Some(1);
+                let stderr = Some("nix-store --query --deriver returned UnknownDeriver".to_string());
+                return Err(NixCmdError::from(CommandError::ProcessFailed { stderr, exit_code }));
+            }
             Ok(DrvOut(PathBuf::from(drv_path)))
         } else {
             let stderr = String::from_utf8(out.stderr).ok();

--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -105,7 +105,7 @@ impl NixStoreCmd {
             }
             Ok(DrvOut(PathBuf::from(drv_path)))
         } else {
-            let stderr = String::from_utf8(out.stderr).ok();
+            let stderr = Some(String::from_utf8_lossy(&out.stderr).to_string());
             let exit_code = out.status.code();
             Err(CommandError::ProcessFailed { stderr, exit_code }.into())
         }
@@ -140,7 +140,7 @@ impl NixStoreCmd {
                 .collect();
             Ok(out)
         } else {
-            let stderr = String::from_utf8(out.stderr).ok();
+            let stderr = Some(String::from_utf8_lossy(&out.stderr).to_string());
             let exit_code = out.status.code();
             Err(CommandError::ProcessFailed { stderr, exit_code }.into())
         }

--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Display},
-    path::PathBuf,
-};
+use std::{fmt, path::PathBuf};
 
 use anyhow::Result;
 use nix_rs::command::{CommandError, NixCmdError};
@@ -154,7 +151,8 @@ impl NixStoreCmd {
     }
 }
 
-/// Errors when running and interpreting the output of a nix command
+/// Errors when running and interpreting the output of a nix command.
+/// Extended with NixCmdError from nix_rs
 #[derive(Error, Debug)]
 pub enum NixStoreCmdError {
     #[error(transparent)]

--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -128,9 +128,11 @@ impl NixStoreCmd {
             Ok(out)
         } else {
             let exit_code = out.status.code().unwrap_or(1);
+            let stderr_output = String::from_utf8(out.stderr)?;
             bail!(
-                "nix-store --query --requisites --include-outputs failed to run (exited: {})",
-                exit_code
+                "nix-store --query --requisites --include-outputs failed to run (exited: {}).\nStderr: {}",
+                exit_code,
+                stderr_output
             );
         }
     }

--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -104,6 +104,8 @@ impl NixStoreCmd {
             }
             Ok(DrvOut(PathBuf::from(drv_path)))
         } else {
+            // TODO(refactor): When upstreaming this module to nix-rs, create a
+            // nicer and unified way to create `ProcessFailed`
             let stderr = Some(String::from_utf8_lossy(&out.stderr).to_string());
             let exit_code = out.status.code();
             Err(CommandError::ProcessFailed { stderr, exit_code }.into())
@@ -136,6 +138,7 @@ impl NixStoreCmd {
                 .collect();
             Ok(out)
         } else {
+            // TODO(refactor): see above
             let stderr = Some(String::from_utf8_lossy(&out.stderr).to_string());
             let exit_code = out.status.code();
             Err(CommandError::ProcessFailed { stderr, exit_code }.into())


### PR DESCRIPTION
When nixci build fails while querying nix-store then we don't get proper error.  It displays error like 

nix-store --query --requisites --include-outputs failed to run (exited: 1).

We can add stderr messages to have proper error message. 