### PR TITLE
feat(cli): Allow `--override-input` to refer to flake name without `flake/` prefix of devour_flake

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,8 +84,7 @@ impl CliArgs {
         // Adjust to devour_flake's expectations
         match &mut self.command {
             Command::Build(build_cfg) => {
-                build_cfg.extra_nix_build_args =
-                    devour_flake::transform_override_inputs(&build_cfg.extra_nix_build_args)?;
+                devour_flake::transform_override_inputs(&mut build_cfg.extra_nix_build_args);
             }
             _ => {}
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,7 +166,7 @@ impl BuildConfig {
                     modified_args.push(format!("flake/{}", next_arg));
                 } else {
                     return Err(anyhow::anyhow!(
-                        "Missing argument after --override-input".to_string()
+                        "Missing argument after --override-input. See: <https://nix.dev/manual/nix/2.22/command-ref/new-cli/nix3-build#opt-override-input>".to_string()
                     ));
                 }
             } else {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,11 +82,8 @@ impl CliArgs {
         // Avoid using `--extra-experimental-features` if possible.
         self.nixcmd = self.nixcmd.with_flakes().await?;
         // Adjust to devour_flake's expectations
-        match &mut self.command {
-            Command::Build(build_cfg) => {
-                devour_flake::transform_override_inputs(&mut build_cfg.extra_nix_build_args);
-            }
-            _ => {}
+        if let Command::Build(build_cfg) = &mut self.command {
+            devour_flake::transform_override_inputs(&mut build_cfg.extra_nix_build_args);
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn nixci(args: CliArgs) -> anyhow::Result<Vec<StorePath>> {
     let cfg = args.command.get_config(&args.nixcmd).await?;
     match args.command {
         cli::Command::Build(build_cfg) => {
-            nixci_build(&args.nixcmd, args.verbose, &build_cfg, &cfg).await
+            nixci_build(&args.nixcmd, args.verbose, &build_cfg.preprocess()?, &cfg).await
         }
         cli::Command::DumpGithubActionsMatrix { systems, .. } => {
             let matrix = github::matrix::GitHubMatrix::from(systems, &cfg.subflakes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn nixci(args: CliArgs) -> anyhow::Result<Vec<StorePath>> {
     let cfg = args.command.get_config(&args.nixcmd).await?;
     match args.command {
         cli::Command::Build(build_cfg) => {
-            nixci_build(&args.nixcmd, args.verbose, &build_cfg.preprocess()?, &cfg).await
+            nixci_build(&args.nixcmd, args.verbose, &build_cfg, &cfg).await
         }
         cli::Command::DumpGithubActionsMatrix { systems, .. } => {
             let matrix = github::matrix::GitHubMatrix::from(systems, &cfg.subflakes);

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -86,25 +86,14 @@ pub async fn devour_flake(
 
 /// Transform `--override-input` arguments to use `flake/` prefix, which
 /// devour_flake expects.
-pub fn transform_override_inputs(args: &Vec<String>) -> Result<Vec<String>> {
-    let mut modified_args = Vec::new();
-    let mut iter = args.iter().peekable();
+pub fn transform_override_inputs(args: &mut Vec<String>) {
+    let mut iter = args.iter_mut().peekable();
 
     while let Some(arg) = iter.next() {
-        if arg == "--override-input" {
-            modified_args.push(arg.clone());
-
+        if *arg == "--override-input" {
             if let Some(next_arg) = iter.next() {
-                modified_args.push(format!("flake/{}", next_arg));
-            } else {
-                return Err(anyhow::anyhow!(
-                    "Missing argument after --override-input. See: <https://nix.dev/manual/nix/2.22/command-ref/new-cli/nix3-build#opt-override-input>".to_string()
-                ));
+                *arg = format!("flake/{}", next_arg);
             }
-        } else {
-            modified_args.push(arg.clone());
         }
     }
-
-    Ok(modified_args)
 }

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -86,7 +86,7 @@ pub async fn devour_flake(
 
 /// Transform `--override-input` arguments to use `flake/` prefix, which
 /// devour_flake expects.
-pub fn transform_override_inputs(args: &mut Vec<String>) {
+pub fn transform_override_inputs(args: &mut [String]) {
     let mut iter = args.iter_mut().peekable();
 
     while let Some(arg) = iter.next() {

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -92,7 +92,7 @@ pub fn transform_override_inputs(args: &mut Vec<String>) {
     while let Some(arg) = iter.next() {
         if *arg == "--override-input" {
             if let Some(next_arg) = iter.next() {
-                *arg = format!("flake/{}", next_arg);
+                *next_arg = format!("flake/{}", next_arg);
             }
         }
     }

--- a/src/nix/devour_flake.rs
+++ b/src/nix/devour_flake.rs
@@ -83,3 +83,28 @@ pub async fn devour_flake(
         bail!("devour-flake failed to run (exited: {})", exit_code);
     }
 }
+
+/// Transform `--override-input` arguments to use `flake/` prefix, which
+/// devour_flake expects.
+pub fn transform_override_inputs(args: &Vec<String>) -> Result<Vec<String>> {
+    let mut modified_args = Vec::new();
+    let mut iter = args.iter().peekable();
+
+    while let Some(arg) = iter.next() {
+        if arg == "--override-input" {
+            modified_args.push(arg.clone());
+
+            if let Some(next_arg) = iter.next() {
+                modified_args.push(format!("flake/{}", next_arg));
+            } else {
+                return Err(anyhow::anyhow!(
+                    "Missing argument after --override-input. See: <https://nix.dev/manual/nix/2.22/command-ref/new-cli/nix3-build#opt-override-input>".to_string()
+                ));
+            }
+        } else {
+            modified_args.push(arg.clone());
+        }
+    }
+
+    Ok(modified_args)
+}


### PR DESCRIPTION
resolves https://github.com/srid/nixci/issues/71