### PR TITLE
fix: `--print-all-dependencies` should ignore `unknown-deriver`

### DIFF
--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -94,7 +94,7 @@ impl NixStoreCmd {
     /// Return the derivation used to build the given build output.
     async fn nix_store_query_deriver(&self, out_path: PathBuf) -> Result<DrvOut, NixStoreCmdError> {
         let mut cmd = self.command();
-        cmd.args(["--query", "--deriver", &out_path.to_string_lossy().as_ref()]);
+        cmd.args(["--query", "--valid-derivers", &out_path.to_string_lossy().as_ref()]);
         nix_rs::command::trace_cmd(&cmd);
         let out = cmd.output().await?;
         if out.status.success() {

--- a/src/nix/nix_store.rs
+++ b/src/nix/nix_store.rs
@@ -94,7 +94,11 @@ impl NixStoreCmd {
     /// Return the derivation used to build the given build output.
     async fn nix_store_query_deriver(&self, out_path: PathBuf) -> Result<DrvOut, NixStoreCmdError> {
         let mut cmd = self.command();
-        cmd.args(["--query", "--valid-derivers", &out_path.to_string_lossy().as_ref()]);
+        cmd.args([
+            "--query",
+            "--valid-derivers",
+            &out_path.to_string_lossy().as_ref(),
+        ]);
         nix_rs::command::trace_cmd(&cmd);
         let out = cmd.output().await?;
         if out.status.success() {


### PR DESCRIPTION
In nixci build while print-all-dependencies option sometimes nix-store query returns `unknown-deriver`  and the returned deriver is not guaranteed to exist in the local store. Hence we should use `--valid-derivers` instead to obtain valid paths only.

Reference: https://github.com/NixOS/nix/blob/142e566adbce587a5ed97d1648a26352f0608ec5/doc/manual/src/command-ref/nix-store/query.md?plain=1#L99C3-L99C61